### PR TITLE
Fixed Segmentation Fault caused by long files

### DIFF
--- a/mteval/utils.cc
+++ b/mteval/utils.cc
@@ -51,8 +51,13 @@ double Utility::calculateLevenshteinDistance(
   int len_ref = ref.size();
   int len_hyp = hyp.size();
 
-  // initialize DP table
-  double dp[len_ref + 1][len_hyp + 1];
+  // initialize DP table as a matrix with len_ref + 1 rows and len_hyp + 1 columns
+  vector< vector<double> > dp;
+  dp.resize(len_ref + 1);
+  for (int i = 0; i <= len_ref; i++) {
+    dp[i].resize(len_hyp + 1);
+  }
+
   for (int i = 0; i <= len_ref; ++i) {
     dp[i][0] = del_weight * static_cast<double>(i);
   }


### PR DESCRIPTION
Problem
======

I have noticed that the tool was crashing when considerable large files were used as input. After a bit of investigation noticed that it was due to the memory that it was trying to allocate on stack.

Fix
===
Using a vector of vectors for 'dp' matrix fixes the problem, since vector is allocated on the heap.